### PR TITLE
Remove joystick commands

### DIFF
--- a/custom_postgui.hal
+++ b/custom_postgui.hal
@@ -46,45 +46,45 @@ net spindle-vel-cmd-rpm-abs pyvcp.motion-spindle-rpm
 #  JOYSTICK_JOYPAD SETUP
 #*******************
 
-loadusr -W hal_input -KRAL ANKO
+#loadusr -W hal_input -KRAL ANKO
 #WATCH OUT for JOY vs. JOG.  
 #commands for the joystick here
-loadrt or2 count=2
-loadrt mux4 count=1
+#loadrt or2 count=2
+#loadrt mux4 count=1
 
-addf or2.0 servo-thread
-addf or2.1 servo-thread
-addf mux4.0 servo-thread
+#addf or2.0 servo-thread
+#addf or2.1 servo-thread
+#addf mux4.0 servo-thread
 
 # set the jog speed for the joypad again use numbers that make sense for your machine
 # this one must be 0 to prevent motion unless a button is pressed
-setp mux4.0.in0 0 
-setp mux4.0.in1 4
-setp mux4.0.in2 20
-setp mux4.0.in3 40
+#setp mux4.0.in0 0 
+#setp mux4.0.in1 4
+#setp mux4.0.in2 20
+#setp mux4.0.in3 40
 #setp mux4.0.in1 25
 #setp mux4.0.in2 100
 #setp mux4.0.in3 200
 
 # the following does the magic of setting the jog speeds
-net remote-speed-slow or2.0.in0 input.0.btn-a
-net remote-speed-medium or2.1.in0 input.0.btn-b
-net remote-speed-fast or2.0.in1 or2.1.in1 input.0.btn-c
+#net remote-speed-slow or2.0.in0 input.0.btn-a
+#net remote-speed-medium or2.1.in0 input.0.btn-b
+#net remote-speed-fast or2.0.in1 or2.1.in1 input.0.btn-c
 
-net joy-speed-1 mux4.0.sel0 <= or2.0.out
-net joy-speed-2 mux4.0.sel1 <= or2.1.out
-net jog-speed <= mux4.0.out
+#net joy-speed-1 mux4.0.sel0 <= or2.0.out
+#net joy-speed-2 mux4.0.sel1 <= or2.1.out
+#net jog-speed <= mux4.0.out
 #net joy-speed-final halui.jog-speed <= mux4.0.out
 #net joy-speed-final jog-speed <= mux4.0.out
 
 #Set up the Axis Add the following to ##### REMOVE FOLLOWING IF WORKS ####  your postgui.hal file 
-net jog-x-analog <= input.0.abs-x-position 
-net jog-y-analog <= input.0.abs-y-position 
-net jog-z-analog <= input.0.abs-z-position 
+#net jog-x-analog <= input.0.abs-x-position 
+#net jog-y-analog <= input.0.abs-y-position 
+#net jog-z-analog <= input.0.abs-z-position 
 
 #Reverse any Axis that go in the wrong direction
-setp input.0.abs-x-scale -63.5
-setp input.0.abs-z-scale -63.5
+#setp input.0.abs-x-scale -63.5
+#setp input.0.abs-z-scale -63.5
 
 #*******************
 #  GEARCHANGE 


### PR DESCRIPTION
Comment out all joystick commands by adding # to each line in that section.  We'll see how it works.

I ran the system one time and LinuxCNC booted up and ran.  Will need to see if it continues to run correctly.